### PR TITLE
WIP: show that pausing dosen't work on task immediately after creation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,8 @@ import {
   DownloadTask
 } from '@kesha-antonov/react-native-background-downloader';
 
+const WAIT_BEFORE_PAUSE = true;
+
 function App(): JSX.Element {
   const [downloading, setDownloading] = useState(false);
   const [paused, setPaused] = useState(false);
@@ -16,15 +18,19 @@ function App(): JSX.Element {
   function onDownload() {
     setDownloading(true);
 
+    const id = 'file' + Math.random().toFixed(3);
     const task = download({
-      id: 'file123',
+      id,
       url: 'https://wavez-prod-podcache.storage.googleapis.com/https___feeds_simplecast_com_3hnxp7yk/6ee807f6_336d_46f6_b6e3_6936e16c525c.mp3',
-      destination: `${directories.documents}/test.jpg`,
+      destination: `${directories.documents}/${id}.mp3}`,
     });
 
     task
       .begin((data: {expectedBytes: number}) => {
         console.log('Download started', data.expectedBytes);
+
+        // Pausing here actually always works.
+        // pauseTask(task);
       })
       .done(() => {
         completeHandler(task.id);
@@ -37,11 +43,19 @@ function App(): JSX.Element {
         console.log('Download progress', percent, bytesWritten, totalBytes);
       });
 
+    // Pausing here only works if you wait a while. Instantly pausing doesn't
+    // do anything.
+    if (WAIT_BEFORE_PAUSE) {
+      setTimeout(() => pauseTask(task), 250);
+    } else {
+      pauseTask(task);
+    }
+
     setTask(task);
   }
 
-  function onPause() {
-    console.log('Attempting to pause download.');
+  function pauseTask(task?: DownloadTask) {
+    console.log('Attempting to pause download with task:', !!task);
     task?.pause();
     setPaused(true);
   }
@@ -62,7 +76,11 @@ function App(): JSX.Element {
       {downloading && (
         <>
           <Text>Downloading...</Text>
-          <Button disabled={paused} onPress={onPause} title="Pause Download" />
+          <Button
+            disabled={paused}
+            onPress={() => pauseTask(task)}
+            title="Pause Download"
+          />
           <Button
             disabled={!paused}
             onPress={onResume}


### PR DESCRIPTION
In this PR, you'll see that `task.pause()` after `download` doesn't work until you either:

- Sleep a bit (more than 0 ms; seems to work with 250ms), or
- wait for `begin` before calling `task.pause()`

This PR is referenced in https://github.com/kesha-antonov/react-native-background-downloader/issues/23 as a repro.